### PR TITLE
Add info func

### DIFF
--- a/gofsutil_fs.go
+++ b/gofsutil_fs.go
@@ -170,7 +170,7 @@ func (fs *FS) MultipathCommand(ctx context.Context, timeoutSeconds time.Duration
 // This function borrowed from https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/util/fs/fs.go#L40
 // Info linux returns (available bytes, byte capacity, byte usage, total inodes, inodes free, inode usage, error)
 // for the filesystem that path resides upon.
-func Info(path string) (int64, int64, int64, int64, int64, int64, error) {
+func FsInfo(path string) (int64, int64, int64, int64, int64, int64, error) {
 	statfs := &unix.Statfs_t{}
 	err := unix.Statfs(path, statfs)
 	if err != nil {

--- a/gofsutil_fs.go
+++ b/gofsutil_fs.go
@@ -167,7 +167,6 @@ func (fs *FS) MultipathCommand(ctx context.Context, timeoutSeconds time.Duration
 	return fs.multipathCommand(ctx, timeoutSeconds, chroot, arguments...)
 }
 
-// This function borrowed from https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/util/fs/fs.go#L40
 // Info linux returns (available bytes, byte capacity, byte usage, total inodes, inodes free, inode usage, error)
 // for the filesystem that path resides upon.
 func FsInfo(path string) (int64, int64, int64, int64, int64, int64, error) {


### PR DESCRIPTION
This PR takes the Info() function from Kubernetes (https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/util/fs/fs.go) and puts it in gofsutil so that we don't have to import K8s in go.mod -- currently, we are importing it solely for this info function. Once this is approved, it will be followed by a PR in csi-powerflex and then a PR in csi-volumegroup-snapshotter.

Testing: made corresponding modifications to the csi-powerflex driver and tested the health monitor -- everything works.