### PR TITLE
Specify folders for gosec to run on, add exclude flag

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Go Security
         uses: securego/gosec@master
+        with:
+          args: ./...
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run Go Security
         uses: securego/gosec@master
         with:
-          args: ./...
+          args: -exclude=G304 ./...
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description
We need to specify a folder for gosec to run on or it won't run correctly. This PR adds that. Additionally, adding this argument caused gosec to complain about a couple of file inclusions via variable, which are being ignored with an exclude flag.

gosec complaints without exclude=G304: https://github.com/dell/gofsutil/runs/5053086180?check_suite_focus=true

# GitHub Issues
None

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Ran actions and checked output to make sure they are working correctly
