### PR TITLE
Fix for wrong arg count

### DIFF
--- a/gofsutil_mount_windows.go
+++ b/gofsutil_mount_windows.go
@@ -36,12 +36,12 @@ func (fs *FS) bindMount(ctx context.Context, source, target string, opts ...stri
 	return errors.New("not implemented")
 }
 
-//resizeFS expands the filesystem to the new size of underlying device
-func (fs *FS) resizeFS(ctx context.Context, volumePath, devicePath, mpathDevice, fsType string) error {
+// resizeFS expands the filesystem to the new size of underlying device
+func (fs *FS) resizeFS(ctx context.Context, volumePath, devicePath, ppathDevice, mpathDevice, fsType string) error {
 	return errors.New("not implemented")
 }
 
-//findFSType fetches the filesystem type on mountpoint
+// findFSType fetches the filesystem type on mountpoint
 func (fs *FS) findFSType(
 	ctx context.Context, mountpoint string) (fsType string, err error) {
 	return "", errors.New("not implemented")
@@ -58,7 +58,7 @@ func (fs *FS) resizeMultipath(ctx context.Context, deviceName string) error {
 	return errors.New("not implemented")
 }
 
-//DeviceRescan rescan the device for size alterations
+// DeviceRescan rescan the device for size alterations
 func (fs *FS) deviceRescan(ctx context.Context,
 	devicePath string) error {
 	return errors.New("not implemented")


### PR DESCRIPTION
<!--
Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->

# Description
Minor fix in `gofsutil_mount_windows.go` for resolving following errors.

![inefassign](https://user-images.githubusercontent.com/36687396/214242238-e93ab1bb-2d34-4a8b-b0b0-2fdb7c21a0a0.png)
![wrongArgCount](https://user-images.githubusercontent.com/36687396/214242245-4e353de4-70ac-46a3-bf7b-787fe2c5d890.png)

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
