### PR TITLE
pscale check during mount failure

### DIFF
--- a/gofsutil_mount_unix.go
+++ b/gofsutil_mount_unix.go
@@ -101,7 +101,7 @@ func (fs *FS) doMount(
 	if err != nil {
 		out := string(buf)
 		//check is explicitly placed for PowerScale driver only
-		if !(strings.Contains(args, "/ifs") && (strings.Contains(out, "access denied by server while mounting") || strings.Contains(out, "No such file or directory"))) {
+		if !(strings.Contains(args, "/ifs") && (strings.Contains(strings.ToLower(out), "access denied by server while mounting") || strings.Contains(strings.ToLower(out), "no such file or directory"))) {
 			log.WithFields(f).WithField("output", out).WithError(
 				err).Error("mount Failed")
 		}

--- a/gofsutil_mount_unix.go
+++ b/gofsutil_mount_unix.go
@@ -100,8 +100,11 @@ func (fs *FS) doMount(
 	buf, err := exec.Command(mntCmd, mountArgs...).CombinedOutput()
 	if err != nil {
 		out := string(buf)
-		log.WithFields(f).WithField("output", out).WithError(
-			err).Error("mount Failed")
+		//check is explicitly placed for PowerScale driver only
+		if !(strings.Contains(args, "/ifs") && (strings.Contains(out, "access denied by server while mounting") || strings.Contains(out, "No such file or directory"))) {
+			log.WithFields(f).WithField("output", out).WithError(
+				err).Error("mount Failed")
+		}
 		return fmt.Errorf(
 			"mount failed: %v\nmounting arguments: %s\noutput: %s",
 			err, args, out)


### PR DESCRIPTION
<!--
Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->

# Description
Added a check before printing "mount failed" error for PowerScale Driver. No impact for others.
Placed condition if satisfied then those logs wont get printed for each mount failure attempt instead simply returns the error message and that will be printed based on condition in Driver code.


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/655|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Build driver image and tested with sanity --> All pass.
Also, performed some negative tests to validate the condition placed. Its as Expected.