### PR TITLE
Update Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,15 +29,12 @@
 # Francis Nijay (francis-nijay)
 # Harish P (harishp8889)
 # Leonard Ulman (Leonard-Dell)
-# Marcin Trajfacki (mtrajfacki-dell)
 # Marek Suski (mareksuski-dell)
-# Mateusz Urbanek (shanduur-dell)
 # Małgorzata Dutka (mdutka-dell)
 # Pooja Prasannakumar (kumarp20)
 # Prsanna Muthukumaraswamy (prablr79)
-# Shanmugapriya M (spriya-m)
 # Trevor Dawe (tdawe)
  
 
 # for all files:
-* @kumarp20 @bpjain2004 @francis-nijay @harishp8889 @spriya-m @prablr79 @hoppea2 @tdawe @coulof @shaynafinocchiaro @sharmilarama @isaiasA1 @arnchiequ-dell @alikdell @atye @adamginna-dell @cbartoszDell @bogdanNovikovDell @Leonard-Dell @mtrajfacki-dell @mareksuski-dell @shanduur-dell @mdutka-dell
+* @kumarp20 @bpjain2004 @francis-nijay @harishp8889 @prablr79 @hoppea2 @tdawe @coulof @shaynafinocchiaro @sharmilarama @isaiasA1 @arnchiequ-dell @alikdell @atye @adamginna-dell @cbartoszDell @bogdanNovikovDell @Leonard-Dell @mareksuski-dell @mdutka-dell

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,17 +19,25 @@
 # be requested for review when someone opens a pull request.
 # order is alphabetical for easier maintenance.
 #
+# Adam Ginna (adamginna-dell)
 # Alexander Hoppe (hoppea2)
 # Arindam Datta (dattaarindam)
 # Bahubali Jain (bahubali-jain)
+# Bartosz Ciesielczyk (cbartoszDell)
+# Bogdan Novikov (bogdanNovikovDell)
+# Florian Coulombel (coulof)
 # Francis Nijay (francis-nijay)
 # Harish P (harishp8889)
+# Leonard Ulman (Leonard-Dell)
+# Marcin Trajfacki (mtrajfacki-dell)
+# Marek Suski (mareksuski-dell)
+# Mateusz Urbanek (shanduur-dell)
+# Małgorzata Dutka (mdutka-dell)
 # Pooja Prasannakumar (kumarp20)
 # Prsanna Muthukumaraswamy (prablr79)
 # Shanmugapriya M (spriya-m)
 # Trevor Dawe (tdawe)
-# Florian Coulombel (coulof)
  
 
 # for all files:
-* @kumarp20 @bpjain2004 @francis-nijay @harishp8889 @spriya-m @prablr79 @hoppea2 @tdawe @coulof @shaynafinocchiaro @sharmilarama @isaiasA1 @arnchiequ-dell @alikdell @atye
+* @kumarp20 @bpjain2004 @francis-nijay @harishp8889 @spriya-m @prablr79 @hoppea2 @tdawe @coulof @shaynafinocchiaro @sharmilarama @isaiasA1 @arnchiequ-dell @alikdell @atye @adamginna-dell @cbartoszDell @bogdanNovikovDell @Leonard-Dell @mtrajfacki-dell @mareksuski-dell @shanduur-dell @mdutka-dell


### PR DESCRIPTION
<!--
Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->

# Description
This PR updates the Codeowners list.
