### PR TITLE
Add exceptions for false alarms for gosec

### DIFF
--- a/gofsutil_mount_linux.go
+++ b/gofsutil_mount_linux.go
@@ -189,8 +189,8 @@ func (fs *FS) formatAndMount(
 		log.Printf("mkfs args: %v", args)
 
 		mkfsCmd := fmt.Sprintf("mkfs.%s", fsType)
-		/* #nosec G204 */
-		if err := exec.Command(mkfsCmd, args...).Run(); err != nil {
+		err := exec.Command(mkfsCmd, args...).Run() // #nosec G204
+		if err != nil {
 			log.WithFields(f).WithError(err).Error(
 				"format of disk failed")
 		} else {
@@ -333,7 +333,7 @@ func (fs *FS) getMpathNameFromDevice(
 	}
 	fmt.Println(cmd)
 
-	buf, _ := exec.Command("bash", "-c", cmd).Output()
+	buf, _ := exec.Command("bash", "-c", cmd).Output() // #nosec G204
 	output := string(buf)
 	mpathDeviceRegx := regexp.MustCompile(`NAME="\S+"`)
 	mpath := mpathDeviceRegx.FindString(output)
@@ -355,7 +355,7 @@ func (fs *FS) getNativeDevicesFromPpath(
 	cmd := fmt.Sprintf("%s/%s", "/noderoot/sbin", ppinqtool)
 	log.Debug("pp_inq cmd:", cmd)
 	args := []string{"-wwn", "-dev", deviceName}
-	out, err := exec.Command(cmd, args...).CombinedOutput()
+	out, err := exec.Command(cmd, args...).CombinedOutput() // #nosec G204
 	if err != nil {
 		log.Errorf("Error powermt display %s: %v", deviceName, err)
 		return devices, err
@@ -574,7 +574,7 @@ func reReadPartitionTable(_ context.Context, devicePath string) error {
 		return fmt.Errorf("Failed to validate path: %s error %v", devicePath, err)
 	}
 	args := []string{path}
-	_, err := exec.Command("partprobe", args...).CombinedOutput()
+	_, err := exec.Command("partprobe", args...).CombinedOutput() // #nosec G204
 	if err != nil {
 		log.Errorf("Failed to execute partprobe on %s: %s", devicePath, err.Error())
 		return err


### PR DESCRIPTION
<!--
Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->

# Description
Add exceptions for false alarms for gosec

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1221 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
