### PR TITLE
Add go version workflow

### DIFF
--- a/.github/workflows/go-version.yaml
+++ b/.github/workflows/go-version.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+# Reusable workflow to perform go version update on Golang based projects
+name: Go Version Update
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [go-update-workflow]
+
+jobs:
+  # go version update
+  go-version-update:
+    uses: dell/common-github-actions/.github/workflows/go-version-workflow.yaml@main
+    name: Go Version Update
+    secrets: inherit

--- a/gofsutil_fs.go
+++ b/gofsutil_fs.go
@@ -192,15 +192,21 @@ func (fs *FS) fsInfo(_ context.Context, path string) (int64, int64, int64, int64
 	}
 
 	// Available is blocks available * fragment size
-	available := int64(statfs.Bavail) * int64(statfs.Bsize)
+	// #nosec G115
+	available := int64(statfs.Bavail) * statfs.Bsize
 
 	// Capacity is total block count * fragment size
-	capacity := int64(statfs.Blocks) * int64(statfs.Bsize)
+	// #nosec G115
+	capacity := int64(statfs.Blocks) * statfs.Bsize
 
 	// Usage is block being used * fragment size (aka block size).
-	usage := (int64(statfs.Blocks) - int64(statfs.Bfree)) * int64(statfs.Bsize)
+	// #nosec G115
+	usage := (int64(statfs.Blocks) - int64(statfs.Bfree)) * statfs.Bsize
 
+	// #nosec G115
 	inodes := int64(statfs.Files)
+
+	// #nosec G115
 	inodesFree := int64(statfs.Ffree)
 	inodesUsed := inodes - inodesFree
 

--- a/gofsutil_mount_unix.go
+++ b/gofsutil_mount_unix.go
@@ -571,7 +571,7 @@ func (fs *FS) multipathCommand(ctx context.Context, timeoutSeconds time.Duration
 		log.Error("multipath command failed: " + err.Error())
 	}
 	if len(textBytes) > 0 {
-		log.Debug(fmt.Printf("multipath output: " + string(textBytes)))
+		log.Debug(fmt.Printf("multipath output: %s", string(textBytes)))
 	}
 	return textBytes, err
 }


### PR DESCRIPTION
# Description
Add caller workflow Go Version Update. It can be manually triggered or it can be triggered by [Trigger Go Version Workflow](https://github.com/dell/common-github-actions/actions/workflows/trigger-go-workflow.yaml).

Why suppress `G115`?
- At some point in the flow, casting to `int64` will be needed when assigning to a `csi` struct.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1490 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
