### PR TITLE
Add NVMe support for block device

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,12 @@ go 1.22
 
 require (
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.13.0
 )
 
-require gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e h1:3i3ny04XV6HbZ2N1oIBw1UBYATHAOpo4tfTF83JM3Z0=

--- a/gofsutil.go
+++ b/gofsutil.go
@@ -84,7 +84,7 @@ var (
 	ErrNotImplemented = errors.New("not implemented")
 
 	// fs is the default FS instance.
-	fs FSinterface = &FS{ScanEntry: defaultEntryScanFunc}
+	fs FSinterface = &FS{ScanEntry: defaultEntryScanFunc, SysBlockDir: "/sys/block"}
 )
 
 // ContextKey is a variable containing context-keys
@@ -98,6 +98,11 @@ const NoDiscard = "NoDiscard"
 // for calls using gofsutils.
 func UseMockFS() {
 	fs = &mockfs{ScanEntry: defaultEntryScanFunc}
+}
+
+// UseMockSysBlockDir creates a file system for testing.
+func UseMockSysBlockDir(mockSysBlockDir string) {
+	fs = &FS{ScanEntry: defaultEntryScanFunc, SysBlockDir: mockSysBlockDir}
 }
 
 // GetDiskFormat uses 'lsblk' to see if the given disk is unformatted.

--- a/gofsutil_fs.go
+++ b/gofsutil_fs.go
@@ -23,6 +23,8 @@ import (
 type FS struct {
 	// ScanEntry is the function used to process mount table entries.
 	ScanEntry EntryScanFunc
+	// SysBlockDir is used to set the directory of block devices.
+	SysBlockDir string
 }
 
 // GetDiskFormat uses 'lsblk' to see if the given disk is unformatted.

--- a/gofsutil_mount_linux.go
+++ b/gofsutil_mount_linux.go
@@ -624,6 +624,11 @@ func (fs *FS) deviceRescan(_ context.Context,
 	var device string
 	if strings.Contains(devicePath, "nvme") {
 		device = path + "/device/rescan_controller"
+		_, err := os.Stat(device)
+		if os.IsNotExist(err) {
+			log.Warnf("This is not a valid nvme controller device %s", device)
+			return nil
+		}
 	} else {
 		device = path + "/device/rescan"
 	}

--- a/gofsutil_mount_linux.go
+++ b/gofsutil_mount_linux.go
@@ -621,7 +621,12 @@ func (fs *FS) deviceRescan(_ context.Context,
 	if err := validatePath(path); err != nil {
 		return err
 	}
-	device := path + "/device/rescan"
+	var device string
+	if strings.Contains(devicePath, "nvme") {
+		device = path + "/device/rescan_controller"
+	} else {
+		device = path + "/device/rescan"
+	}
 	args := []string{"-c", "echo 1 > " + device}
 	log.Infof("Executing rescan command on device (%s)", devicePath)
 	/* #nosec G204 */

--- a/gofsutil_mount_test.go
+++ b/gofsutil_mount_test.go
@@ -133,12 +133,12 @@ func TestGetSysBlockDevicesForVolumeWWN(t *testing.T) {
 			path := []string{tempDir, tt.deviceName}
 			path = append(path, tt.deviceWwidPath...)
 			deviceWwidFile := filepath.Join(path...)
-			err := os.MkdirAll(filepath.Dir(deviceWwidFile), 0755)
+			err := os.MkdirAll(filepath.Dir(deviceWwidFile), 0o755)
 			require.Nil(t, err)
 			if strings.HasPrefix(tt.deviceName, "nvme") {
-				err = os.WriteFile(deviceWwidFile, []byte(tt.nguid), 0600)
+				err = os.WriteFile(deviceWwidFile, []byte(tt.nguid), 0o600)
 			} else {
-				err = os.WriteFile(deviceWwidFile, []byte(tt.wwn), 0600)
+				err = os.WriteFile(deviceWwidFile, []byte(tt.wwn), 0o600)
 			}
 			require.Nil(t, err)
 
@@ -191,9 +191,9 @@ func TestDeviceRescan(t *testing.T) {
 			devicePath := tt.deviceName
 			if !strings.Contains(tt.name, "invalid") {
 				devicePath = filepath.Join(tempDir, tt.deviceName)
-				err := os.MkdirAll(filepath.Dir(deviceRescanFile), 0755)
+				err := os.MkdirAll(filepath.Dir(deviceRescanFile), 0o755)
 				require.Nil(t, err)
-				err = os.WriteFile(deviceRescanFile, nil, 0600)
+				err = os.WriteFile(deviceRescanFile, nil, 0o600)
 				require.Nil(t, err)
 			}
 

--- a/gofsutil_mount_test.go
+++ b/gofsutil_mount_test.go
@@ -136,9 +136,9 @@ func TestGetSysBlockDevicesForVolumeWWN(t *testing.T) {
 			err := os.MkdirAll(filepath.Dir(deviceWwidFile), 0755)
 			require.Nil(t, err)
 			if strings.HasPrefix(tt.deviceName, "nvme") {
-				err = os.WriteFile(deviceWwidFile, []byte(tt.nguid), 0644)
+				err = os.WriteFile(deviceWwidFile, []byte(tt.nguid), 0600)
 			} else {
-				err = os.WriteFile(deviceWwidFile, []byte(tt.wwn), 0644)
+				err = os.WriteFile(deviceWwidFile, []byte(tt.wwn), 0600)
 			}
 			require.Nil(t, err)
 
@@ -193,7 +193,7 @@ func TestDeviceRescan(t *testing.T) {
 				devicePath = filepath.Join(tempDir, tt.deviceName)
 				err := os.MkdirAll(filepath.Dir(deviceRescanFile), 0755)
 				require.Nil(t, err)
-				err = os.WriteFile(deviceRescanFile, nil, 0644)
+				err = os.WriteFile(deviceRescanFile, nil, 0600)
 				require.Nil(t, err)
 			}
 

--- a/gofsutil_mount_unix.go
+++ b/gofsutil_mount_unix.go
@@ -643,10 +643,9 @@ func (fs *FS) issueLIPToAllFCHosts(_ context.Context) error {
 func (fs *FS) getSysBlockDevicesForVolumeWWN(_ context.Context, volumeWWN string) ([]string, error) {
 	start := time.Now()
 	result := make([]string, 0)
-	sysBlockDir := "/sys/block"
-	sysBlocks, err := os.ReadDir(sysBlockDir)
+	sysBlocks, err := os.ReadDir(fs.SysBlockDir)
 	if err != nil {
-		return result, fmt.Errorf("Error reading %s: %s", sysBlockDir, err)
+		return result, fmt.Errorf("Error reading %s: %s", fs.SysBlockDir, err)
 	}
 
 	for _, sysBlock := range sysBlocks {
@@ -659,9 +658,9 @@ func (fs *FS) getSysBlockDevicesForVolumeWWN(_ context.Context, volumeWWN string
 		// Set the WWID path based on the device type
 		var wwidPath string
 		if strings.HasPrefix(name, "nvme") {
-			wwidPath = sysBlockDir + "/" + name + "/wwid" // For NVMe devices
+			wwidPath = fs.SysBlockDir + "/" + name + "/wwid" // For NVMe devices
 		} else {
-			wwidPath = sysBlockDir + "/" + name + "/device/wwid" // For SCSI devices
+			wwidPath = fs.SysBlockDir + "/" + name + "/device/wwid" // For SCSI devices
 		}
 
 		bytes, err := os.ReadFile(filepath.Clean(wwidPath))

--- a/gofsutil_mount_unix.go
+++ b/gofsutil_mount_unix.go
@@ -38,6 +38,13 @@ import (
 // The 'options' parameter is a list of options. Please see mount(8) for
 // more information. If no options are required then please invoke Mount
 // with an empty or nil argument.
+
+// PowerMaxOUIPrefix - PowerMax format 6 OUI prefix
+var PowerMaxOUIPrefix = "6000097"
+
+// PowerStoreOUIPrefix - PowerStore format 6 OUI prefix
+var PowerStoreOUIPrefix = "68ccf09"
+
 func (fs *FS) mount(
 	ctx context.Context,
 	source, target, fsType string,
@@ -708,11 +715,6 @@ func wwnMatches(nguid, wwn string) bool {
 			nguid: wwn[last16] 		+ wwn[1:6] 	+ wwn[0] + wwn[7:15]
 				   1263533030313434 + 000097 	+ 6		 + 000012000
 	*/
-	// PowerMaxOUIPrefix - PowerMax format 6 OUI prefix
-	PowerMaxOUIPrefix := "6000097"
-
-	// PowerStoreOUIPrefix - PowerStore format 6 OUI prefix
-	PowerStoreOUIPrefix := "68ccf09"
 	if len(wwn) < 32 {
 		return false
 	}

--- a/gofsutil_mount_unix.go
+++ b/gofsutil_mount_unix.go
@@ -648,24 +648,97 @@ func (fs *FS) getSysBlockDevicesForVolumeWWN(_ context.Context, volumeWWN string
 	if err != nil {
 		return result, fmt.Errorf("Error reading %s: %s", sysBlockDir, err)
 	}
+
 	for _, sysBlock := range sysBlocks {
 		name := sysBlock.Name()
-		if !strings.HasPrefix(name, "sd") {
+		// Check for both "sd" and "nvme" prefixes
+		if !strings.HasPrefix(name, "sd") && !strings.HasPrefix(name, "nvme") {
 			continue
 		}
-		wwidPath := sysBlockDir + "/" + name + "/device/wwid"
+
+		// Set the WWID path based on the device type
+		var wwidPath string
+		if strings.HasPrefix(name, "nvme") {
+			wwidPath = sysBlockDir + "/" + name + "/wwid" // For NVMe devices
+		} else {
+			wwidPath = sysBlockDir + "/" + name + "/device/wwid" // For SCSI devices
+		}
+
 		bytes, err := os.ReadFile(filepath.Clean(wwidPath))
 		if err != nil {
 			continue
 		}
+
 		wwid := strings.TrimSpace(string(bytes))
-		wwid = strings.Replace(wwid, "naa.", "", 1)
-		if wwid == volumeWWN {
-			result = append(result, name)
+
+		// Replace "eui." for NVMe devices and "naa." for others
+		if strings.HasPrefix(name, "nvme") {
+			wwid = strings.Replace(wwid, "eui.", "", 1)
+			// Use wwnMatches for NVMe comparison
+			if wwnMatches(wwid, volumeWWN) {
+				result = append(result, name)
+			}
+		} else {
+			wwid = strings.Replace(wwid, "naa.", "", 1)
+			// Compare directly for SCSI devices
+			if wwid == volumeWWN {
+				result = append(result, name)
+			}
 		}
 	}
+
 	end := time.Now()
 	dur := end.Sub(start)
 	log.Printf("getSysBlockDevicesForVolumeWWN %d %f", len(sysBlocks), dur.Seconds())
 	return result, nil
+}
+
+func wwnMatches(nguid, wwn string) bool {
+	/*
+			// PowerStore
+			Sample wwn : naa.68ccf098001111a2222b3d4444a1b23c
+			token1: 1111a2222b3d4444
+			token2: a1b23c
+			Sample nguid : 1111a2222b3d44448ccf096800a1b23c
+
+			// PowerMax
+			nguid: 12635330303134340000976000012000
+			wwn:   60000970000120001263533030313434
+		           11aaa111111111a11a111a1111aa1111
+		           1a111a1111aa1111 1aaa11 1 1111111a1
+			nguid: wwn[last16] 		+ wwn[1:6] 	+ wwn[0] + wwn[7:15]
+				   1263533030313434 + 000097 	+ 6		 + 000012000
+	*/
+	// PowerMaxOUIPrefix - PowerMax format 6 OUI prefix
+	PowerMaxOUIPrefix := "6000097"
+
+	// PowerStoreOUIPrefix - PowerStore format 6 OUI prefix
+	PowerStoreOUIPrefix := "68ccf09"
+	if len(wwn) < 32 {
+		return false
+	}
+
+	wwn = strings.ToLower(wwn)
+	if strings.HasPrefix(wwn, "naa.") {
+		wwn = wwn[4:]
+	}
+
+	var token1, token2 string
+	if strings.HasPrefix(wwn, PowerStoreOUIPrefix) {
+		token1 = wwn[13 : len(wwn)-7]
+		token2 = wwn[len(wwn)-6 : len(wwn)-1]
+		log.Infof("PowerStore: %s %s %s %t", token1, token2, nguid, strings.Contains(nguid, token2))
+		if strings.Contains(nguid, token1) && strings.Contains(nguid, token2) {
+			return true
+		}
+	} else if strings.HasPrefix(wwn, PowerMaxOUIPrefix) {
+		token1 = wwn[16:]
+		token2 = wwn[1:7]
+		log.Infof("Powermax: %s %s %s %t", token1, token2, nguid, strings.HasPrefix(nguid, token1+token2))
+		if strings.HasPrefix(nguid, token1+token2) {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
<!--
Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->

# Description
Add support to find nvme block device based on wwn and rescan a nvme device.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1534 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] UT
![image](https://github.com/user-attachments/assets/62e54fc9-3827-462e-8ddf-b294733a6fd1)
![image](https://github.com/user-attachments/assets/decaba9d-57dc-47ef-bf4f-df95ab1bc276)

- [x] Tested volume expansion with PowerStore
![image](https://github.com/user-attachments/assets/71b72b31-ce02-4086-9130-e387d4f61667)

