### PR TITLE
Casting Bsize to Int64 to work with GoARCH=386

### DIFF
--- a/gofsutil_fs.go
+++ b/gofsutil_fs.go
@@ -193,15 +193,15 @@ func (fs *FS) fsInfo(_ context.Context, path string) (int64, int64, int64, int64
 
 	// Available is blocks available * fragment size
 	// #nosec G115
-	available := int64(statfs.Bavail) * statfs.Bsize
+	available := int64(statfs.Bavail) * int64(statfs.Bsize)
 
 	// Capacity is total block count * fragment size
 	// #nosec G115
-	capacity := int64(statfs.Blocks) * statfs.Bsize
+	capacity := int64(statfs.Blocks) * int64(statfs.Bsize)
 
 	// Usage is block being used * fragment size (aka block size).
 	// #nosec G115
-	usage := (int64(statfs.Blocks) - int64(statfs.Bfree)) * statfs.Bsize
+	usage := (int64(statfs.Blocks) - int64(statfs.Bfree)) * int64(statfs.Bsize)
 
 	// #nosec G115
 	inodes := int64(statfs.Files)


### PR DESCRIPTION
<!--
Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->

# Description
Build fails with a type mismatch error related to the statfs.Bsize field in the gofsutil package. This issue occurs only when the Go environment is set to target a 32-bit architecture (GOARCH=386), even if the underlying system is 64-bit.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1858|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Run the make command in both GOARCH=386 & GOARCH=amd64 by updating the commit id of gofsutil in karavi resilency and running make command gets executed successfully.
![image](https://github.com/user-attachments/assets/aca489dc-c5c0-4262-b1fd-bcbeeab9d020)

