### PR TITLE
check for empty volume name

### DIFF
--- a/gofsutil_mount_linux.go
+++ b/gofsutil_mount_linux.go
@@ -395,7 +395,6 @@ func (fs *FS) getNativeDevicesFromPpath(
 func (fs *FS) getMountInfoFromDevice(
 	ctx context.Context, devID string,
 ) (*DeviceMountInfo, error) {
-
 	if devID == "" {
 		return nil, fmt.Errorf("device ID cannot be empty")
 	}


### PR DESCRIPTION
<!--
Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->

# Description
Added check to return error if volume name is empty when getting mount info of a device

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Previously, if volume name was empty, getMountInfoFromDevice was still returning sda data which was not required.
<img width="1387" height="167" alt="image" src="https://github.com/user-attachments/assets/814ad1d6-c7a4-4e8e-873c-4a63349b532a" />

Added check to return error when volume name is empty
